### PR TITLE
Fixed helm chart route routeName

### DIFF
--- a/helm-charts/sonatype-nexus/templates/route.yaml
+++ b/helm-charts/sonatype-nexus/templates/route.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   host: {{ .Values.route.path }}
   port:
-    targetPort: {{ .Values.service.portName }}
+    targetPort: {{ .Values.route.portName }}
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge


### PR DESCRIPTION
The helm chart has an issue, the helm chart is not able to create the route as it tries to get the portName from the service instead of the route.